### PR TITLE
Add .distignore support as in deploy action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ Because the WordPress.org plugin repository shows information from `readme.txt` 
 
 **Important note:** If your development process leads to a situation where `master` (or other specified branch) only contains changes to `readme.txt` or `assets` since the last sync to the plugin directory and those changes are in preparation for the next release, those changes will go live and potentially be misleading to users. Usage of this Action assumes a fairly traditional Git methodology that involves merging all changes to `master` when functional changes are ready and that this seemingly unlikely situation will therefore not happen in your repo; there are no safeguards against syncing changes based on readme/asset content, as that cannot be predicted.
 
+### ☞ This Action is meant to be used in tandem with our [WordPress.org Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy)
+
 ## Configuration
 
 ### Required secrets
 * `SVN_USERNAME`
 * `SVN_PASSWORD`
 
-Secrets can be set while editing your workflow or in the repository settings. They cannot be viewed once stored. [GitHub secrets documentation](https://developer.github.com/actions/creating-workflows/storing-secrets/)
+[Secrets are set in your repository settings](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables). They cannot be viewed once stored.
 
 ### Optional environment variables
-* `SLUG` - defaults to the respository name, customizable in case your WordPress repository has a different slug. This should be a very rare case as WordPress assumes that the directory and initial plugin file have the same slug.
+* `SLUG` - defaults to the repository name, customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`)
 
 ## Example Workflow File
@@ -52,3 +54,4 @@ Want to help? Check out our [contributing guidelines](CONTRIBUTING.md) to get st
 
 Our GitHub Actions are available for use and remix under the MIT license.
 
+### ☞ Check out our [collection of WordPress-focused GitHub Actions](https://github.com/10up/actions-wordpress)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,38 +41,47 @@ svn update --set-depth infinity assets
 svn update --set-depth infinity trunk
 
 echo "➤ Copying files..."
-cd "$GITHUB_WORKSPACE"
+if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
+	echo "ℹ︎ Using .distignore"
+	# Copy from current branch to /trunk, excluding dotorg assets
+	# The --delete flag will delete anything in destination that no longer exists in source
+	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete
+else
+	echo "ℹ︎ Using .gitattributes"
 
-# "Export" a cleaned copy to a temp directory
-TMP_DIR="/github/archivetmp"
-mkdir "$TMP_DIR"
+	cd "$GITHUB_WORKSPACE"
 
-git config --global user.email "10upbot+github@10up.com"
-git config --global user.name "10upbot on GitHub"
+	# "Export" a cleaned copy to a temp directory
+	TMP_DIR="/github/archivetmp"
+	mkdir "$TMP_DIR"
 
-# If there's no .gitattributes file, write a default one into place
-if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
-	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
-	/$ASSETS_DIR export-ignore
-	/.gitattributes export-ignore
-	/.gitignore export-ignore
-	/.github export-ignore
-	EOL
+	git config --global user.email "10upbot+github@10up.com"
+	git config --global user.name "10upbot on GitHub"
 
-	# Ensure we are in the $GITHUB_WORKSPACE directory, just in case
-	# The .gitattributes file has to be committed to be used
-	# Just don't push it to the origin repo :)
-	git add .gitattributes && git commit -m "Add .gitattributes file"
+	# If there's no .gitattributes file, write a default one into place
+	if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
+		cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
+		/$ASSETS_DIR export-ignore
+		/.gitattributes export-ignore
+		/.gitignore export-ignore
+		/.github export-ignore
+		EOL
+
+		# Ensure we are in the $GITHUB_WORKSPACE directory, just in case
+		# The .gitattributes file has to be committed to be used
+		# Just don't push it to the origin repo :)
+		git add .gitattributes && git commit -m "Add .gitattributes file"
+	fi
+
+	# This will exclude everything in the .gitattributes file with the export-ignore flag
+	git archive HEAD | tar x --directory="$TMP_DIR"
+
+	cd "$SVN_DIR"
+
+	# Copy from clean copy to /trunk, excluding dotorg assets
+	# The --delete flag will delete anything in destination that no longer exists in source
+	rsync -rc "$TMP_DIR/" trunk/ --delete
 fi
-
-# This will exclude everything in the .gitattributes file with the export-ignore flag
-git archive HEAD | tar x --directory="$TMP_DIR"
-
-cd "$SVN_DIR"
-
-# Copy from clean copy to /trunk, excluding dotorg assets
-# The --delete flag will delete anything in destination that no longer exists in source
-rsync -rc "$TMP_DIR/" trunk/ --delete
 
 # Copy dotorg assets to /assets
 rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,7 +83,7 @@ svn status
 
 if [[ -z $(svn stat) ]]; then
 	echo "🛑 Nothing to deploy!"
-	exit 78
+	exit 0
 # Check if there is more than just the readme.txt modified in trunk
 # The leading whitespace in the pattern is important
 # so it doesn't match potential readme.txt in subdirectories!


### PR DESCRIPTION
### Description of the Change

Adds support for `.distignore` as in https://github.com/10up/action-wordpress-plugin-deploy/pull/3

### Alternate Designs

n/a but I do wonder if maybe this code path needs to be in its own SVN repo prep action or otherwise somehow shared because it doesn't make sense to keep maintaining them separately.

### Benefits

Won't get false failures on merging to `master` if you've switched to using `.distignore`.

### Possible Drawbacks

n/a

### Verification Process

Still not sure how to test these Actions but the exact same code worked in the deploy action

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

### Applicable Issues

Fixes #2, fixes #4 
