### PR TITLE
Fix: Stable tag not being updated when readme is updated

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,10 @@ svn update --set-depth infinity trunk
 echo "➤ Copying files..."
 if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
 	echo "ℹ︎ Using .distignore"
+
+	# Use $TMP_DIR as the source of truth
+	TMP_DIR=$GITHUB_WORKSPACE
+
 	# Copy from current branch to /trunk, excluding dotorg assets
 	# The --delete flag will delete anything in destination that no longer exists in source
 	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete
@@ -103,7 +107,7 @@ fi
 
 # Readme also has to be updated in the .org tag
 echo "➤ Preparing stable tag..."
-STABLE_TAG=$(grep -m 1 "^Stable tag:" "$GITHUB_WORKSPACE/readme.txt" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
+STABLE_TAG=$(grep -m 1 "^Stable tag:" "$TMP_DIR/readme.txt" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
 
 if [ -z "$STABLE_TAG" ]; then
     echo "ℹ︎ Could not get stable tag from readme.txt";
@@ -115,7 +119,7 @@ else
 		svn update --set-depth infinity "tags/$STABLE_TAG"
 
 		# Not doing the copying in SVN for the sake of easy history
-		rsync -c "$GITHUB_WORKSPACE/readme.txt" "tags/$STABLE_TAG/"
+		rsync -c "$TMP_DIR/readme.txt" "tags/$STABLE_TAG/"
 	else
 		echo "ℹ︎ Tag $STABLE_TAG not found"
 	fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,7 +103,7 @@ fi
 
 # Readme also has to be updated in the .org tag
 echo "➤ Preparing stable tag..."
-STABLE_TAG=$(grep -m 1 "^Stable tag:" "$TMP_DIR/readme.txt" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
+STABLE_TAG=$(grep -m 1 "^Stable tag:" "$GITHUB_WORKSPACE/readme.txt" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
 
 if [ -z "$STABLE_TAG" ]; then
     echo "ℹ︎ Could not get stable tag from readme.txt";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,7 +115,7 @@ else
 		svn update --set-depth infinity "tags/$STABLE_TAG"
 
 		# Not doing the copying in SVN for the sake of easy history
-		rsync -c "$TMP_DIR/readme.txt" "tags/$STABLE_TAG/"
+		rsync -c "$GITHUB_WORKSPACE/readme.txt" "tags/$STABLE_TAG/"
 	else
 		echo "ℹ︎ Tag $STABLE_TAG not found"
 	fi


### PR DESCRIPTION
### Description of the Change

Fixes an error where readme changes are not deployed to the stable tag.
When reading the stable tag from the readme.txt, the incorrect file location is being searched which causes the bug.

### Verification Process

The PR is tested to deploy to correct stable tag ([action run log](https://github.com/brainstormforce/pre-publish-checklist/commit/4363f25efde84e22efa7ad69ed3bebecf6db7743/checks#step:4:75))

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterward/ while the PR is open._ -->

### Applicable Issues

Fixes #7 

### Changelog Entry

Fix: readme.txt not being updated to the correct stable tag.
