### PR TITLE
use .gitignore when checking the changed files 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ echo "ℹ︎ README_NAME is $README_NAME"
 SVN_URL="http://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="/github/svn-${SLUG}"
 EXCLUDE_FROM_GITIGNORE=""
-if [[ -e "$GITHUB_WORKSPACE/.gitignore" ]];
+if [[ -e "$GITHUB_WORKSPACE/.gitignore" ]]; then
   EXCLUDE_FROM_GITIGNORE=" --exclude-from=$GITHUB_WORKSPACE/.gitignore "
 fi
 # Checkout just trunk and assets for efficiency

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,10 @@ echo "ℹ︎ README_NAME is $README_NAME"
 
 SVN_URL="http://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="/github/svn-${SLUG}"
-
+EXCLUDE_FROM_GITIGNORE=""
+if [[ -e "$GITHUB_WORKSPACE/.gitignore" ]];
+  EXCLUDE_FROM_GITIGNORE=" --exclude-from=$GITHUB_WORKSPACE/.gitignore "
+fi
 # Checkout just trunk and assets for efficiency
 # Stable tag will come later, if applicable
 echo "➤ Checking out .org repository..."
@@ -54,7 +57,7 @@ if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
 
 	# Copy from current branch to /trunk, excluding dotorg assets
 	# The --delete flag will delete anything in destination that no longer exists in source
-	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete
+	rsync -rc $EXCLUDE_FROM_GITIGNORE --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete
 else
 	echo "ℹ︎ Using .gitattributes"
 
@@ -89,7 +92,7 @@ else
 
 	# Copy from clean copy to /trunk, excluding dotorg assets
 	# The --delete flag will delete anything in destination that no longer exists in source
-	rsync -rc "$TMP_DIR/" trunk/ --delete
+	rsync -rc $EXCLUDE_FROM_GITIGNORE "$TMP_DIR/" trunk/ --delete
 fi
 
 # Copy dotorg assets to /assets


### PR DESCRIPTION
 
### Description of the Change
When using a workflow where some files are ignored on git but they are present on wordpress.org SVN, it's impossible to update the readme or any assets as the svn sees the git ignored files as changed. 
 
### Verification Process
I've tested on one of our projects, here you have the run [log](https://github.com/Codeinwp/blocks-css/commit/6546f9abc2593178213be2e615195efc0666012e/checks?check_suite_id=387978258) of the action.

### Checklist:
 
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
 

### Applicable Issues

#12  
