### PR TITLE
Fix: assets getting force downloaded

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,6 +95,11 @@ fi
 # Copy dotorg assets to /assets
 rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete --delete-excluded
 
+# Fix screenshots getting force downloaded when clicking them
+# https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
+svn propset svn:mime-type image/png assets/*.png || true
+svn propset svn:mime-type image/jpeg assets/*.jpg || true
+
 echo "➤ Preparing files..."
 
 svn status


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Fixes #20 

Replicate the changes in action-wordpress-plugin-deploy#40 to fix the issue that images are downloading when people click on them from the WordPress.org plugin directory page.
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->