### PR TITLE
add support for stable tag in unordered Markdown lists in README

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -112,7 +112,7 @@ fi
 
 # Readme also has to be updated in the .org tag
 echo "➤ Preparing stable tag..."
-STABLE_TAG=$(grep -m 1 "^Stable tag:" "$TMP_DIR/$README_NAME" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
+STABLE_TAG=$(grep -m 1 -E "^([*+-]\s+)?Stable tag:" "$TMP_DIR/$README_NAME" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
 
 if [[ -z "$STABLE_TAG" ]]; then
     echo "ℹ︎ Could not get stable tag from $README_NAME";


### PR DESCRIPTION
### Description of the Change

Extend the regular expression for stable tag extraction from `^Stable tag:` to `^([*+-]\s+)?Stable tag:`.

Doing so both forms

```
Stable tag:    1.2.3
```

and

```markdown
* Stable tag:   1.2.3
```

```markdown
- Stable tag:   1.2.3
```

```markdown
+ Stable tag:   1.2.3
```

are supported.

Using `grep -E` for extended regular expression, support required for the optional group.

### Alternate Designs

The proposed workaround in #25 was to remove the start of line expression, i.e. use only `Stable tag:`. This solution would also match the "Stable tag:" phrase anywhere within the text. However unlikely to appear, this is definitely not intended.

### Benefits

The action now properly supports Markdown README files with unordered lists.

### Possible Drawbacks

Assuming `grep -E` is available in any environment and a couple of microseconds for the extended regex processing doesn't matter, I can't think of any real drawback.

### Verification Process

Change the README file from plain text
```
=== My Plugin ===
Contributors:      Contri Butor
Requires at least: 4.0
Tested up to:      5.7
Requires PHP:      7.0
Stable tag:        1.2.3
License:           GPLv2 or later
License URI:       https://www.gnu.org/licenses/gpl-2.0.html
```

to Markdown

```markdown
# My Plugin
* Contributors:      Contri Butor
* Requires at least: 4.0
* Tested up to:      5.7
* Requires PHP:      7.0
* Stable tag:        1.2.3
* License:           GPLv2 or later
* License URI:       https://www.gnu.org/licenses/gpl-2.0.html
``` 

(equivalent with dash `-` or plus `+` instead of the asterisk `*`)

The action should no longer raise "Could not get stable tag from README.md" for the latter and update the tag (here: 1.2.3) accordingly.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Applicable Issues

resolves #25

### Changelog Entry

### Added
- Support for unordered Markdown lists in `README.md` for stable tag declaration.
