### PR TITLE
Move to composite run steps action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM debian:stable-slim
-
-RUN apt-get update \
-	&& apt-get install -y subversion rsync git \
-	&& apt-get clean -y \
-	&& rm -rf /var/lib/apt/lists/*
-
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -7,3 +7,9 @@ runs:
 branding:
   icon: 'upload-cloud'
   color: 'blue'
+runs:
+  using: 'composite'
+  steps:
+    - id: deploy
+      run: ${{ github.action_path }}/deploy.sh
+      shell: bash

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,7 +35,7 @@ fi
 echo "ℹ︎ README_NAME is $README_NAME"
 
 SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
-SVN_DIR="/github/svn-${SLUG}"
+SVN_DIR="${HOME}/svn-${SLUG}"
 
 # Checkout just trunk and assets for efficiency
 # Stable tag will come later, if applicable
@@ -61,7 +61,7 @@ else
 	cd "$GITHUB_WORKSPACE"
 
 	# "Export" a cleaned copy to a temp directory
-	TMP_DIR="/github/archivetmp"
+	TMP_DIR="${HOME}/archivetmp"
 	mkdir "$TMP_DIR"
 
 	git config --global user.email "10upbot+github@10up.com"


### PR DESCRIPTION
Parallel to https://github.com/10up/action-wordpress-plugin-deploy/pull/74, where the Debian image is failing because of a new Debian release. This is almost certainly going to happen here as well, it's just used less often than the other action.

### Alternate Designs

n/a

### Benefits

Isn't broken, runs super fast

### Possible Drawbacks

No drawbacks although it's not fixing any other reported bugs

### Verification Process

Brought over the same changes from what worked in the other action, still haven't manually tested though.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

I didn't open one, oops. See https://github.com/10up/action-wordpress-plugin-deploy/issues/73

### Changelog Entry

Still needs
