### PR TITLE
If IGNORE_OTHER_FILES is true, only copy readme.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Because the WordPress.org plugin repository shows information from the readme in
 * `SLUG` - defaults to the respository name, customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
 * `README_NAME` - defaults to `readme.txt`, customizable in case you use `README.md` instead, which is now quietly supported in the WordPress.org plugin repository.
+* `IGNORE_OTHER_FILES` - defaults to `false`, which means that all your files are copied (as in [WordPress.org Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy), respecting `.distignore` and `.gitignore`), and the Action will bail if anything except assets and `readme.txt` are modified. See "Important note" above. If you set this variable to `true`, then only assets and `readme.txt` will be copied, and changes to other files will be ignored and not committed.
 
 ## Example Workflow File
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Because the WordPress.org plugin repository shows information from the readme in
 * `SLUG` - defaults to the respository name, customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
 * `README_NAME` - defaults to `readme.txt`, customizable in case you use `README.md` instead, which is now quietly supported in the WordPress.org plugin repository.
-* `IGNORE_OTHER_FILES` - defaults to `false`, which means that all your files are copied (as in [WordPress.org Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy), respecting `.distignore` and `.gitignore`), and the Action will bail if anything except assets and `readme.txt` are modified. See "Important note" above. If you set this variable to `true`, then only assets and `readme.txt` will be copied, and changes to other files will be ignored and not committed.
+* `IGNORE_OTHER_FILES` - defaults to `false`, which means that all your files are copied (as in [WordPress.org Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy), respecting `.distignore` and `.gitattributes`), and the Action will bail if anything except assets and `readme.txt` are modified. See "Important note" above. If you set this variable to `true`, then only assets and `readme.txt` will be copied, and changes to other files will be ignored and not committed.
 
 ## Example Workflow File
 


### PR DESCRIPTION
Adds an ENV variable `IGNORE_OTHER_FILES` which defaults to `false`.

If someone overrides it with `true`, then instead of the big complicated copying logic, this will happen:

```bash
# Copy readme.txt to /trunk
cp "$GITHUB_WORKSPACE/$README_NAME" trunk/$README_NAME

# Use $TMP_DIR as the source of truth
TMP_DIR=$GITHUB_WORKSPACE
```

This means that the only thing that will be committed is `readme.txt` (`trunk` and stable tag), and the assets.

This maintains full back compat, but fixes #12