### PR TITLE
Release: 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
-## [2.1.1] - 2022-08-16
+## [2.1.1] - 2022-08-7
 ### Added
 - Add correct mime type for gif and SVG images (props [@ocean90](https://github.com/ocean90) via [#38](https://github.com/10up/action-wordpress-plugin-asset-update/pull/38)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+## [2.1.1] - 2022-08-16
+### Added
+- Add correct mime type for gif and SVG images (props [@ocean90](https://github.com/ocean90) via [#38](https://github.com/10up/action-wordpress-plugin-asset-update/pull/38)).
+
 ## [2.1.0] - 2022-04-12
 ### Added
 - Environment variable (`IGNORE_OTHER_FILES`) allowing to deploy updates to readme and/or assets without checking other files (props [@markjaquith](https://github.com/markjaquith) via [#32](https://github.com/10up/action-wordpress-plugin-asset-update/pull/32)).
@@ -48,6 +52,7 @@ This is now a composite Action, meaning that it runs directly on the GitHub Acti
 - Use more robust method of copying files (`-c` flag for `rsync`).
 
 [Unreleased]: https://github.com/10up/action-wordpress-plugin-asset-update/compare/stable...develop
+[2.1.1]: https://github.com/10up/action-wordpress-plugin-asset-update/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/10up/action-wordpress-plugin-asset-update/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/10up/action-wordpress-plugin-asset-update/compare/1.4.1...2.0.0
 [1.4.1]: https://github.com/10up/action-wordpress-plugin-asset-update/compare/1.4.0...1.4.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,16 +28,6 @@ This repository currently uses the `develop` branch to reflect active work and `
 
 ## Release instructions
 
-A new release pull request with the following steps will be created automatically once a branch named `release/X.Y.Z` is pushed to GitHub. Release PR can also be created manually when something unexpected happens.
+A new release pull requestwill be created automatically once a branch named `release/X.Y.Z` is pushed to GitHub.
 
-- [ ] Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-- [ ] Changelog: Add/update the changelog in `CHANGELOG.md`. 
-- [ ] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
-- [ ] Readme updates: Make any other readme changes as necessary in `README.md`.
-- [ ] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
-- [ ] Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
-- [ ] Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-asset-update/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-asset-update/releases).
-- [ ] Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-readme-assets-update) correctly.
-- [ ] Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
-- [ ] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
-- [ ] Celebrate shipping!
+The step by step release instructions can be found in [.github/release-pull-request-template.md](.github/release-pull-request-template.md).

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -4,7 +4,7 @@ The following acknowledges the Maintainers for this repository, those who have C
 
 The following individuals are responsible for curating the list of issues, responding to pull requests, and ensuring regular releases happen.
 
-[Tung Du (@dinhtungdu)](https://github.com/dinhtungdu), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul).
+[Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul).
 
 ## Contributors
 


### PR DESCRIPTION
- [x] Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
- [x] Changelog: Add/update the changelog in `CHANGELOG.md`. 
- [x] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
- [x] Readme updates: Make any other readme changes as necessary in `README.md`.
- [x] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
- [x] Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
- [x] Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-asset-update/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-asset-update/releases).
- [x] Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-readme-assets-update) correctly.
- [x] Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
- [x] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
- [x] Celebrate shipping!