### PR TITLE
Create release PR automatically when a release branch is pushed to GitHub

### DIFF
--- a/.github/release-pull-request-template.md
+++ b/.github/release-pull-request-template.md
@@ -1,11 +1,11 @@
 - [x] Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-- [] Changelog: Add/update the changelog in `CHANGELOG.md`. 
-- [] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
-- [] Readme updates: Make any other readme changes as necessary in `README.md`.
-- [] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
-- [] Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
-- [] Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-asset-update/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-asset-update/releases).
-- [] Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-readme-assets-update) correctly.
-- [] Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
-- [] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
-- [] Celebrate shipping!
+- [ ] Changelog: Add/update the changelog in `CHANGELOG.md`. 
+- [ ] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
+- [ ] Readme updates: Make any other readme changes as necessary in `README.md`.
+- [ ] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
+- [ ] Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
+- [ ] Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-asset-update/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-asset-update/releases).
+- [ ] Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-readme-assets-update) correctly.
+- [ ] Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
+- [ ] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
+- [ ] Celebrate shipping!

--- a/.github/release-pull-request-template.md
+++ b/.github/release-pull-request-template.md
@@ -1,0 +1,11 @@
+- [x] Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
+- [] Changelog: Add/update the changelog in `CHANGELOG.md`. 
+- [] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
+- [] Readme updates: Make any other readme changes as necessary in `README.md`.
+- [] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
+- [] Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
+- [] Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-asset-update/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-asset-update/releases).
+- [] Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-readme-assets-update) correctly.
+- [] Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
+- [] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
+- [] Celebrate shipping!

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -9,18 +9,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Render template
-        id: template
-        uses: chuhlomin/render-template@v1.4
-        with:
-          template: .github/release-pull-request-template.md
       - name: Generate title
         run: |
-          VERSION=${github.ref#'release/'}
+          BRANCH=${GITHUB_REF##*/}
+          echo $BRANCH
+          VERSION=${BRANCH#'release/'}
           echo ::set-output name=result::"Release: ${VERSION}"
         id: title
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: devops-infra/action-pull-request@v0.5.0
         with:
-          body: ${{ steps.template.outputs.result }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          target_branch: develop
           title: ${{ steps.title.outputs.result }}
+          template: .github/release-pull-request-template.md

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -1,0 +1,26 @@
+name: Release Pull Request Automation
+
+on:
+  create:
+jobs:
+  release-pull-request-automation:
+    if: ${{ github.event.ref_type == 'branch' && contains( github.ref, 'release/' ) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Render template
+        id: template
+        uses: chuhlomin/render-template@v1.4
+        with:
+          template: .github/release-pull-request-template.md
+      - name: Generate title
+        run: |
+          VERSION=${github.ref#'release/'}
+          echo ::set-output name=result::"Release: ${VERSION}"
+        id: title
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          body: ${{ steps.template.outputs.result }}
+          title: ${{ steps.title.outputs.result }}

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -17,9 +17,6 @@ jobs:
           echo ::set-output name=result::"Release: ${VERSION}"
         id: title
       - name: Create Pull Request
-        uses: devops-infra/action-pull-request@v0.5.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          target_branch: develop
-          title: ${{ steps.title.outputs.result }}
-          template: .github/release-pull-request-template.md
+        run: gh pr create --title "${{ steps.title.outputs.result }}" --body-file ./.github/release-pull-request-template.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ This repository currently uses the `develop` branch to reflect active work and `
 
 ## Release instructions
 
-1. [Create a new release](https://github.com/10up/action-wordpress-plugin-asset-update/releases/new)
-2. Ensure it appears in the GitHub Marketplace correctly
-3. Celebrate shipping!
+A new release pull request with the following steps will be created automatically once a branch named `release/X.Y.Z` is pushed to GitHub. Release PR can also be created manually when something unexpected happens.
+
+- [ ] Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
+- [ ] Changelog: Add/update the changelog in `CHANGELOG.md`. 
+- [ ] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
+- [ ] Readme updates: Make any other readme changes as necessary in `README.md`.
+- [ ] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
+- [ ] Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
+- [ ] Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-asset-update/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-asset-update/releases).
+- [ ] Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-readme-assets-update) correctly.
+- [ ] Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-asset-update/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
+- [ ] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
+- [ ] Celebrate shipping!


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds a new workflow that creates a release PR automatically when a release branch is pushed to GitHub.

Pushing `release/2.1.1` to GitHub for the first time:
- A PR named `Release: 2.1.1` is created.
- The PR content is taken from `./.github/release-pull-request-template.md`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
See https://github.com/dinhtungdu/action-wordpress-plugin-asset-update/pull/2 and https://github.com/dinhtungdu/action-wordpress-plugin-asset-update/runs/7851250382?check_suite_focus=true

### Changelog Entry

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dinhtungdu


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
