### PR TITLE
Check if ASSETS_DIR exists before sync assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Because the WordPress.org plugin repository shows information from the readme in
 ### Optional environment variables
 
 * `SLUG` - defaults to the respository name, customizable in case your WordPress repository has a different slug or is capitalized differently.
-* `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
+* `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`). And if you ever want not to update assets and you don't have any assets directory, use `SKIP_ASSETS : true`
 * `README_NAME` - defaults to `readme.txt`, customizable in case you use `README.md` instead, which is now quietly supported in the WordPress.org plugin repository.
 * `IGNORE_OTHER_FILES` - defaults to `false`, which means that all your files are copied (as in [WordPress.org Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy), respecting `.distignore` and `.gitattributes`), and the Action will bail if anything except assets and `readme.txt` are modified. See "Important note" above. If you set this variable to `true`, then only assets and `readme.txt` will be copied, and changes to other files will be ignored and not committed.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -105,9 +105,9 @@ else
 	fi
 fi
 
-# Copy dotorg assets to /assets if directory exists
-if [ -d "$GITHUB_WORKSPACE/$ASSETS_DIR" ]; then
-    rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete --delete-excluded
+# Do not sync assets if SKIP_ASSETS set to true
+if [[ "$SKIP_ASSETS" != "true" ]]; then
+     rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete --delete-excluded
 fi
 
 # Fix screenshots getting force downloaded when clicking them

--- a/deploy.sh
+++ b/deploy.sh
@@ -105,8 +105,10 @@ else
 	fi
 fi
 
-# Copy dotorg assets to /assets
-rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete --delete-excluded
+# Copy dotorg assets to /assets if directory exists
+if [ -d "$GITHUB_WORKSPACE/$ASSETS_DIR" ]; then
+    rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete --delete-excluded
+fi
 
 # Fix screenshots getting force downloaded when clicking them
 # https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/


### PR DESCRIPTION
**Problem:** 
Sometimes we may want to push readme.txt file only and not create any .wordpress-org at all. I had this situation when I was just planning to update readme.txt and didn't create any .wordpress-org folder. But faced error: No such file or directory. 

**Solution would be like**
Check if ASSETS_DIR exists before running 
`rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete --delete-excluded` in the line 109. 

```
if [ -d "$GITHUB_WORKSPACE/$ASSETS_DIR" ]; then
    rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete --delete-excluded
fi
```

This should fix the error in the screenshot below. 

**Designs**
![image](https://user-images.githubusercontent.com/6356552/217604453-935f00dd-cad7-4aac-a649-56685187b9e2.png)
