### PR TITLE
Add option to ignore changes to the `vendor` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Because the WordPress.org plugin repository shows information from the readme in
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`). If you want to skip updating assets because you don't have an assets directory, set `SKIP_ASSETS : true`
 * `README_NAME` - defaults to `readme.txt`, customizable in case you use `README.md` instead, which is now quietly supported in the WordPress.org plugin repository.
 * `IGNORE_OTHER_FILES` - defaults to `false`, which means that all your files are copied (as in [WordPress.org Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy), respecting `.distignore` and `.gitattributes`), and the Action will bail if anything except assets and `readme.txt` are modified. See "Important note" above. If you set this variable to `true`, then only assets and `readme.txt` will be copied, and changes to other files will be ignored and not committed.
+* `IGNORE_VENDOR_DIR` - defaults to `false`. If you want to ignore any changes made in the `vendor` directory, set this to `true`. For example, if you have production dependencies that are managed by Composer, you'll often run into issues where the contents of the `vendor` directory are modified during the build process and this Action will bail because of those changes. Setting this to `true` will revert those changes before committing to the svn repo.
 
 ## Example Git Workflow
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -39,6 +39,11 @@ if [[ -z "$IGNORE_OTHER_FILES" ]]; then
 fi
 echo "ℹ︎ IGNORE_OTHER_FILES is $IGNORE_OTHER_FILES"
 
+if [[ -z "$IGNORE_VENDOR_DIR" ]]; then
+	IGNORE_VENDOR_DIR=false
+fi
+echo "ℹ︎ IGNORE_VENDOR_DIR is $IGNORE_VENDOR_DIR"
+
 SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="${HOME}/svn-${SLUG}"
 
@@ -127,6 +132,12 @@ fi
 
 echo "➤ Preparing files..."
 
+# If we want to ignore changes in the vendor directory, revert those back
+if [[ "$IGNORE_VENDOR_DIR" == "true" ]]; then
+	echo "ℹ︎ Reverting changes in vendor directory"
+	svn revert --depth=infinity trunk/vendor
+fi
+
 svn status
 
 if [[ -z $(svn stat) ]]; then
@@ -168,7 +179,7 @@ svn add . --force > /dev/null
 # Also suppress stdout here
 svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
 
-#Resolves => SVN commit failed: Directory out of date
+# Resolves => SVN commit failed: Directory out of date
 svn update
 
 # Now show full SVN status

--- a/deploy.sh
+++ b/deploy.sh
@@ -58,7 +58,7 @@ svn update --set-depth infinity trunk
 echo "➤ Copying files..."
 if [ "$IGNORE_OTHER_FILES" = true ]; then
 	# Copy readme.txt to /trunk
-	cp "$GITHUB_WORKSPACE/$README_NAME" trunk/$README_NAME
+	cp "$GITHUB_WORKSPACE/$README_NAME" "trunk/$README_NAME"
 
 	# Use $TMP_DIR as the source of truth
 	TMP_DIR=$GITHUB_WORKSPACE

--- a/deploy.sh
+++ b/deploy.sh
@@ -133,7 +133,7 @@ fi
 echo "➤ Preparing files..."
 
 # If we want to ignore changes in the vendor directory, revert those back
-if [[ "$IGNORE_VENDOR_DIR" == "true" ]]; then
+if [[ "$IGNORE_VENDOR_DIR" == "true" ]] && svn stat trunk | grep -qi -e " trunk/vendor$" -e " trunk/vendor/"; then
 	echo "ℹ︎ Reverting changes in vendor directory"
 	svn revert --depth=infinity trunk/vendor
 fi


### PR DESCRIPTION
### Description of the Change

Multiple times when using this Action we've run into issues where trying to push out changes to the `readme.txt` file don't work due to `Other files have been modified; changes not deployed`. Finally looked into this closer and the problem is the same as described in #49.

If you have a plugin that uses composer to install non-dev dependencies (or just use it for the autoloader), when running this Action, you'll typically run `composer install --no-dev` as part of a build step. Composer will use a hash for some of the function names and this hash may change each time things are built.

When this Action then compares the files from the svn repo to what is in Github, those composer generated files don't match up due to these different hash values, resulting in the above error.

You can get around this by utilizing the existing `IGNORE_OTHER_FILES` argument but the downside here, at least in the way we have things set up, anytime we push out a new release the changes to the `readme.txt` file will get deployed first by this Action and then the actual release will go out later. Not sure that will cause problems but it's not ideal. I did experiment with conditionally setting the value of `IGNORE_OTHER_FILES` when needed and while this did work, it's not the ideal workflow.

What I eventually decided on was introducing a new configuration option (`IGNORE_VENDOR_DIR`) that defaults to `false` (and thus won't change any existing behavior). But if set to `true`, after we've synced files from Github to our checked out svn repo but before checking to see if there's other file changes we don't want, we revert any changes made to the `vendor` directory.

Closes #49 

### How to test the Change

Not sure if there's a best practice to how to test things here without accidentally deploying things to the .org svn repo but here's the steps I took that others can follow:

1. Checkout this branch
2. In the `deploy.sh` file, comment out lines 11-14 and 16-19. These lines deal with setting the svn username and password, which we don't want to do to avoid accidentally committing changes
3. In the `deploy.sh` file, comment out lines 188-191. These lines are what actually commit the changes. They shouldn't work without a proper username and password but I feel better removing those
4. Clone a plugin that uses composer and run whatever production build steps this plugin needs. Goal is to end up with a plugin built the same way you would before deploying it to .org 
5. We then need some environment variables set:
- SLUG: set this to a valid plugin slug that you have cloned locally; ex `export SLUG='ad-refresh-control'`
- GITHUB_WORKSPACE: set this to the path locally to the cloned plugin; ex `export GITHUB_WORKSPACE='/Users/user/sites/oss/app/public/wp-content/plugins/Ad-Refresh-Control'`
6. Then run the script: `./deploy.sh`. You should get an error about other files being modified and right above that line, you should see some `vendor` directories being flagged
7. Utilize the new configuration option from this PR: `export IGNORE_VENDOR_DIR=true`
8. Run `./deploy.sh` again. You should get a message saying `Nothing to deploy!` and right above that you should see lines about reverting the `vendor` directory 

### Changelog Entry

> Added - New configuration option, `IGNORE_VENDOR_DIR`, that can be used to ignore any changes to the `vendor` directory.

### Credits

Props @dkotter, @cadic

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
