### PR TITLE
Update action examples to install svn

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install SVN ( Subversion )
-      run: sudo apt-get install subversion  
+      run: |
+        sudo apt-get update
+        sudo apt-get install subversion
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
       env:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Install SVN ( Subversion )
+      run: sudo apt-get install subversion  
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
       env:


### PR DESCRIPTION
### Description of the Change
This PR updates the example to install svn same as it is done in https://github.com/10up/action-wordpress-plugin-deploy/pull/155

Closes N/A
