### PR TITLE
Run SVN installation in own step.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,27 @@ branding:
 runs:
   using: 'composite'
   steps:
-    - id: deploy
+    - name: Determine if SVN needs to be installed
+      id: svn-install-check
+      run: |
+        if ! command -v svn &> /dev/null; then
+          echo "svn-installed=false" >> $GITHUB_OUTPUT
+        else
+          echo "svn-installed=true" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+    - name: Install SVN
+      if: steps.svn-install-check.outputs.svn-installed == 'false'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y subversion
+        # Verify installation
+        if ! command -v svn &> /dev/null; then
+          echo "SVN installation failed."
+          exit 1
+        fi
+      shell: bash
+    - name: Deploy asset update to WordPress Plugin Repository
+      id: deploy
       run: ${{ github.action_path }}/deploy.sh
       shell: bash

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,31 +4,6 @@
 # doesn't match I want to be able to show an error first
 set -eo
 
-# Function to check if a command exists
-command_exists() {
-	command -v "$1" >/dev/null 2>&1
-}
-
-# Check if SVN is installed
-if command_exists svn; then
-	echo "SVN is already installed."
-else
-	echo "SVN is not installed. Installing SVN..."
-
-	# Update the package list
-	sudo apt-get update -y
-
-	# Install SVN
-	sudo apt-get install -y subversion
-
-	# Verify installation
-	if command_exists svn; then
-		echo "SVN was successfully installed."
-	else
-		echo "Failed to install SVN. Please check your system configuration."
-		exit 1
-	fi
-fi
 
 # Ensure SVN username and password are set
 # IMPORTANT: while secrets are encrypted and not viewable in the GitHub UI,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Moves the installation of SVN out of the main deploy step to remove the install logs from the deploy action in order to focus the deploy step on the actual deployment.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #67

### How to test the Change

This will require testing in a seperate repo using the commit hash. I'll provide links once I have done so.


### Changelog Entry
> Changed - Moved SVN installation to own step in the GitHub actions.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
